### PR TITLE
Add explicit int return type to prevent compile error with C99

### DIFF
--- a/build
+++ b/build
@@ -748,9 +748,12 @@ LIB_TGT=`echo $LIB_DIR | sed -e 's,.*:,,'`
 #
 # If these were set prior to here, we will just use whatever value was set.
 #
-[ "$DST_DIR" = "" ] && DST_DIR=$SRC_DIR/dist	export DST_DIR
-[ "$UTL_DIR" = "" ] && UTL_DIR=$SRC_DIR/util	export UTL_DIR
-[ "$WIN_DIR" = "" ] && WIN_DIR=$SRC_DIR/ecur	export WIN_DIR
+[ "$DST_DIR" = "" ] && DST_DIR=$SRC_DIR/dist
+export DST_DIR
+[ "$UTL_DIR" = "" ] && UTL_DIR=$SRC_DIR/util
+export UTL_DIR
+[ "$WIN_DIR" = "" ] && WIN_DIR=$SRC_DIR/ecur
+export WIN_DIR
 
 # ------------------------------------------------------------------------
 # get SKU package directory

--- a/libres/resmkch.c
+++ b/libres/resmkch.c
@@ -10,7 +10,7 @@
 /*------------------------------------------------------------------------
  * get list of res entries
  */
-static res_get_list (RES_LIST *rl, char *msgbuf)
+static int res_get_list (RES_LIST *rl, char *msgbuf)
 {
 	FILE *	fp;
 	int		rc;


### PR DESCRIPTION
Add explicit int return type to prevent compile error with C99:
resmkch.c:13:8: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int])